### PR TITLE
Prefer a static reducer

### DIFF
--- a/__tests__/Context-test.js
+++ b/__tests__/Context-test.js
@@ -48,7 +48,7 @@ describe("ReComponent", () => {
       this.state = { count: 0 };
     }
 
-    reducer(action, state) {
+    static reducer(action, state) {
       switch (action.type) {
         case "CLICK":
           return Update({ count: state.count + 1 });

--- a/__tests__/ReComponent-test.js
+++ b/__tests__/ReComponent-test.js
@@ -26,7 +26,7 @@ describe("ReComponent", () => {
       this.state = { count: 0 };
     }
 
-    reducer(action, state) {
+    static reducer(action, state) {
       switch (action.type) {
         case "CLICK":
           return Update({ count: state.count + 1 });
@@ -74,7 +74,7 @@ describe("ReComponent", () => {
         super();
         setState = () => this.setState({ some: "state" });
       }
-      reducer() {}
+      static reducer() {}
       render() {
         return null;
       }
@@ -98,7 +98,7 @@ describe("ReComponent", () => {
           click = this.createSender("CLICK");
         }
 
-        reducer(action, state) {
+        static reducer(action, state) {
           return {};
         }
 
@@ -111,6 +111,38 @@ describe("ReComponent", () => {
       expect(() => click()).not.toThrowError();
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("warns when the reducer is not static", () => {
+    let originalWarn = console.warn;
+    try {
+      console.warn = jest.fn();
+
+      let click;
+      class ClassPropertyReducer extends ReComponent {
+        constructor() {
+          super();
+          click = this.createSender("CLICK");
+        }
+
+        reducer(action, state) {
+          return NoUpdate();
+        }
+
+        render() {
+          return null;
+        }
+      }
+
+      ReactDOM.render(<ClassPropertyReducer />, container);
+      expect(() => click()).not.toThrowError();
+
+      expect(console.warn).toHaveBeenCalledWith(
+        "ClassPropertyReducer(...): Class property `reducer` methods are deprecated. Please upgrade to `static` reducers instead: https://github.com/philipp-spiess/react-recomponent#why-is-the-reducer-static"
+      );
+    } finally {
+      console.warn = originalWarn;
     }
   });
 });

--- a/__tests__/ReComponentImmutable-test.js
+++ b/__tests__/ReComponentImmutable-test.js
@@ -30,7 +30,7 @@ describe("ReComponentImmutable", () => {
       return State();
     }
 
-    reducer(action, state) {
+    static reducer(action, state) {
       switch (action.type) {
         case "CLICK":
           return Update(state.update("count", count => count + 1));

--- a/__tests__/RePureComponent-test.js
+++ b/__tests__/RePureComponent-test.js
@@ -25,7 +25,7 @@ describe("RePureComponent", () => {
       this.state = { count: 0 };
     }
 
-    reducer(action, state) {
+    static reducer(action, state) {
       switch (action.type) {
         case "CLICK":
           return Update({ count: state.count + 1 });

--- a/__tests__/UpdateTypes-test.js
+++ b/__tests__/UpdateTypes-test.js
@@ -40,17 +40,18 @@ describe("UpdateTypes", () => {
       this.state = { count: 0 };
     }
 
-    reducer(action, state) {
+    static reducer(action, state) {
       switch (action.type) {
         case "NO_UPDATE":
           return NoUpdate();
         case "UPDATE":
           return Update({ count: state.count + 1 });
         case "SIDE_EFFECTS":
-          return SideEffects(() => sideEffectSpy());
+          return SideEffects(sideEffectSpy);
         case "UPDATE_WITH_SIDE_EFFECTS":
-          return UpdateWithSideEffects({ count: state.count + 1 }, () =>
-            sideEffectSpy()
+          return UpdateWithSideEffects(
+            { count: state.count + 1 },
+            sideEffectSpy
           );
         case "INVALID":
           return {};
@@ -106,7 +107,7 @@ describe("UpdateTypes", () => {
       const instance = ReactDOM.render(<ReducerReturns />, container);
       sideEffects();
       expect(container.textContent).toEqual("You’ve clicked 0 times(s)");
-      expect(sideEffectSpy).toHaveBeenCalled();
+      expect(sideEffectSpy).toHaveBeenCalledWith(instance);
     });
 
     it("does not re-render", () => {
@@ -121,7 +122,7 @@ describe("UpdateTypes", () => {
       const instance = ReactDOM.render(<ReducerReturns />, container);
       updateWithSideEffects();
       expect(container.textContent).toEqual("You’ve clicked 1 times(s)");
-      expect(sideEffectSpy).toHaveBeenCalled();
+      expect(sideEffectSpy).toHaveBeenCalledWith(instance);
     });
 
     it("re-renders", () => {

--- a/type-definitions/ReComponent.js.flow
+++ b/type-definitions/ReComponent.js.flow
@@ -7,19 +7,18 @@
 import * as React from "react";
 
 declare opaque type UpdateType;
-declare type fn = () => mixed;
 
 export type Sender<AT, A = mixed> = (a: A) => { action: AT, payload: A };
 
 declare export function NoUpdate(): {| type: UpdateType |};
 declare export function Update<S>(state: S): {| type: UpdateType, state: S |};
-declare export function SideEffects(
-  sideEffects: fn
-): {| type: UpdateType, sideEffects: fn |};
-declare export function UpdateWithSideEffects<S>(
+declare export function SideEffects<T>(
+  sideEffects: (T) => mixed
+): {| type: UpdateType, sideEffects: T => mixed |};
+declare export function UpdateWithSideEffects<S, T>(
   state: S,
-  sideEffects: fn
-): {| type: UpdateType, state: S, sideEffects: fn |};
+  sideEffects: (T) => mixed
+): {| type: UpdateType, state: S, sideEffects: T => mixed |};
 
 declare export class ReComponent<
   Props,
@@ -28,14 +27,14 @@ declare export class ReComponent<
 > extends React.Component<Props, State> {
   initialState(props: Props): State;
 
-  reducer(
+  static reducer(
     action: { type: ActionType },
     state: State
   ):
     | {| type: UpdateType |}
     | {| type: UpdateType, state: $Shape<State> |}
-    | {| type: UpdateType, sideEffects: fn |}
-    | {| type: UpdateType, state: $Shape<State>, sideEffects: fn |};
+    | {| type: UpdateType, sideEffects: ($Subtype<ReComponent<Props, State, ActionType>>) => mixed |}
+    | {| type: UpdateType, state: $Shape<State>, sideEffects: ($Subtype<ReComponent<Props, State, ActionType>>) => mixed |};
 
   send(action: { type: ActionType, payload?: mixed }): void;
 

--- a/type-definitions/__tests__/ReComponent.js
+++ b/type-definitions/__tests__/ReComponent.js
@@ -18,7 +18,7 @@ class UntypedActionTypes extends ReComponent<{}, { count: number }> {
 
   state = { count: 0 };
 
-  reducer(action, state) {
+  static reducer(action, state) {
     switch (action.type) {
       case "CLICK":
         return Update({ count: state.count + 1 });
@@ -43,7 +43,7 @@ class StateMismatch extends ReComponent<{}, { count: number }> {
   // $ExpectError
   state = { invalid: "state" };
 
-  reducer(action, state) {
+  static reducer(action, state) {
     switch (action.type) {
       case "A":
         return Update({});
@@ -60,16 +60,28 @@ class StateMismatch extends ReComponent<{}, { count: number }> {
 }
 
 class UpdateTypes extends ReComponent<{}, { count: number }> {
-  reducer(action, state) {
+  // Used to test the callback property of SideEffects
+  someClassProperty: number;
+
+  static reducer(action, state) {
     switch (action.type) {
       case "A":
         return NoUpdate();
       case "B":
         return Update({ count: 1 });
       case "C":
-        return SideEffects(() => true);
+        return SideEffects((instance: UpdateTypes) => {
+          instance.someClassProperty = 1;
+          // $ExpectError
+          instance.someClassProperty = "1";
+        });
       default:
-        return UpdateWithSideEffects({ count: 1 }, () => true);
+        return UpdateWithSideEffects({ count: 1 }, (instance: UpdateTypes) => {
+          instance.someClassProperty = 1;
+          // $ExpectError
+          instance.someClassProperty = "1";
+
+        });
     }
   }
 }
@@ -81,7 +93,7 @@ class TypedActionTypes extends ReComponent<{}, { count: number }, "CLICK"> {
   // $ExpectError
   handleBar = this.createSender();
 
-  reducer(action, state) {
+  static reducer(action, state) {
     switch (action.type) {
       case "CLICK":
         return NoUpdate();
@@ -120,7 +132,7 @@ class ExhaustivelyTypedFailingActionTypes extends ReComponent<
   { count: number },
   "CLICK" | "CLACK"
 > {
-  reducer(action, state) {
+  static reducer(action, state) {
     switch (action.type) {
       case "CLICK":
         return NoUpdate();
@@ -137,7 +149,7 @@ class ExhaustivelyTypedPassingActionTypes extends ReComponent<
   { count: number },
   "CLICK" | "CLACK"
 > {
-  reducer(action, state) {
+  static reducer(action, state) {
     switch (action.type) {
       case "CLICK":
         return NoUpdate();


### PR DESCRIPTION
Fixes #3

A `static` reducer will not only improve the code because it leaves less room for side effects, it will also make individual actions easier to test.

Side effects still should have access to the instance (e.g. to access refs). To enable this, all side effects will now be called with a reference to the component as the first argument.

Previous, class property reducers will still work until the 1.0.0 release to avoid making a breaking change in a minor version.