### PR TITLE
Remove deprecated class property reducer

### DIFF
--- a/__tests__/ReComponent-test.js
+++ b/__tests__/ReComponent-test.js
@@ -106,36 +106,4 @@ describe("ReComponent", () => {
       process.env.NODE_ENV = originalNodeEnv;
     }
   });
-
-  it("warns when the reducer is not static", () => {
-    let originalWarn = console.warn;
-    try {
-      console.warn = jest.fn();
-
-      let click;
-      class ClassPropertyReducer extends ReComponent {
-        constructor() {
-          super();
-          click = () => this.send({ type: "CLICK" });
-        }
-
-        reducer(action, state) {
-          return NoUpdate();
-        }
-
-        render() {
-          return null;
-        }
-      }
-
-      ReactDOM.render(<ClassPropertyReducer />, container);
-      expect(() => click()).not.toThrowError();
-
-      expect(console.warn).toHaveBeenCalledWith(
-        "ClassPropertyReducer(...): Class property `reducer` methods are deprecated. Please upgrade to `static` reducers instead: https://github.com/philipp-spiess/react-recomponent#why-is-the-reducer-static"
-      );
-    } finally {
-      console.warn = originalWarn;
-    }
-  });
 });

--- a/__tests__/__snapshots__/ReComponent-test.js.snap
+++ b/__tests__/__snapshots__/ReComponent-test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`ReComponent disables \`setState\` 1`] = `"Example(...): Calls to \`setState\` are not allowed. Please use the \`reducer\` method to update the component state"`;
 
-exports[`ReComponent errors when no \`reducer\` method is defined 1`] = `"Example(...): No \`reducer\` method found on the returned component instance: did you define a reducer?"`;
+exports[`ReComponent errors when no \`reducer\` method is defined 1`] = `"Example(...): No static \`reducer\` method found on the returned component instance: did you define a reducer?"`;

--- a/src/re.js
+++ b/src/re.js
@@ -13,24 +13,11 @@ export function Re(Component) {
       if (process.env.NODE_ENV !== "production") {
         const name = this.displayName || this.constructor.name;
 
-        const isStaticReducer = typeof this.constructor.reducer === "function";
-        const isPropertyReducer = typeof this.reducer === "function";
-
-        // @TODO: Remove property reducer support with v1.0.0
-        if (isPropertyReducer) {
-          console.warn(
-            name +
-              "(...): Class property `reducer` methods are deprecated. Please " +
-              "upgrade to `static` reducers instead: " +
-              "https://github.com/philipp-spiess/react-recomponent#why-is-the-reducer-static"
-          );
-        }
-
-        if (!(isStaticReducer || isPropertyReducer)) {
+        if (typeof this.constructor.reducer !== "function") {
           throw new Error(
             name +
-              "(...): No `reducer` method found on the returned component " +
-              "instance: did you define a reducer?"
+              "(...): No static `reducer` method found on the returned " +
+              "component instance: did you define a reducer?"
           );
         }
       }
@@ -96,12 +83,7 @@ export function Re(Component) {
         let sideEffects;
 
         const updater = state => {
-          let reduced;
-          if (typeof this.reducer === "function") {
-            reduced = this.reducer(action, state);
-          } else {
-            reduced = this.constructor.reducer(action, state);
-          }
+          const reduced = this.constructor.reducer(action, state);
 
           if (process.env.NODE_ENV !== "production") {
             if (typeof reduced === "undefined") {

--- a/type-definitions/ReComponent.js.flow
+++ b/type-definitions/ReComponent.js.flow
@@ -21,7 +21,7 @@ declare export function UpdateWithSideEffects<S, T>(
 declare export class ReComponent<
   Props,
   State,
-  Action: { +type: string },
+  Action: { +type: string }
 > extends React.Component<Props, State> {
   initialState(props: Props): State;
 
@@ -39,11 +39,15 @@ declare export class ReComponent<
       |};
 
   send(action: Action): void;
-  createSender<A: Action>(actionType: $ElementType<A, 'type'>): (mixed) => A;
+  createSender<A: Action>(actionType: $ElementType<A, "type">): mixed => A;
 
   // This type is only used when initialState returns an Immutable.js data type.
   // Consider this API unstable.
   +immutableState: State;
 }
 
-declare export class RePureComponent<P, S, A: { +type: string }> extends ReComponent<P, S, A> {}
+declare export class RePureComponent<
+  P,
+  S,
+  A: { +type: string }
+> extends ReComponent<P, S, A> {}


### PR DESCRIPTION
For the upcoming v1.0.0-rc1, we want to remove support for the deprecated class property reducer.