### PR TITLE
Add "dont use this.send in componentWillUnmount" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ ReComponent comes with four different types of [effects](https://github.com/phil
 
 By intelligently using any of the four types above, it is possible to transition between states in one place and without the need to use `setState()` manually. This drastically simplifies our mental model since changes must always go through the reducer first.
 
+**NOTE!**
+You should NEVER call `this.send` or any sender in **`componentWillUnmount`**.
+If you need to execute a side-effect in **`componentWillUnmount`** (e.g. clear a timer) call that side-effect directly.
+
+
 ## FAQ
 
 ### Advantages Over `setState`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ By intelligently using any of the four types above, it is possible to transition
 You should NEVER call `this.send` or any sender in **`componentWillUnmount`**.
 If you need to execute a side-effect in **`componentWillUnmount`** (e.g. clear a timer) call that side-effect directly.
 
-
 ## FAQ
 
 ### Advantages Over `setState`


### PR DESCRIPTION
Just wanted to clarify a confusing moment: "shall I always call side-effects through sending an action?" 
React [docs](https://reactjs.org/docs/react-component.html#componentwillunmount) say that you should never call `setState` in `componentWillUnmount` and `this.send` eventually calls `setState`, so I believe we should make it clear that we shouldn't call `this.send` in `componentWillUnmount` either.

What do you think?