### PR TITLE
Link component state with reducer

### DIFF
--- a/type-definitions/ReComponent.d.ts
+++ b/type-definitions/ReComponent.d.ts
@@ -50,11 +50,11 @@ export type Action = {
   type: string;
 };
 
-export class ReComponent<P = {}, S = {}> extends Component<P, S> {
-  static reducer<TState, TAction extends Action, TSideEffect = any>(
+export class ReComponent<P = {}, State = {}> extends Component<P, State> {
+  static reducer<TAction extends Action, TSideEffect = any>(
     action: Action,
-    state: TState
-  ): ReducerAction<TState, TSideEffect>;
+    state: State
+  ): ReducerAction<State, TSideEffect>;
 
   send<TAction extends Action>(action: TAction): void;
 


### PR DESCRIPTION
Currently when I annotate my component and my reducer with same State type I get an incompatibility error
```
error TS2417: Class static side 'typeof MyComponent' incorrectly extends base class static side 'typeof ReComponent'.                                                
  Types of property 'reducer' are incompatible.                                                                                                                                                                     
    Type '(action: Action, state: State) => NoUpdateAction' is not assignable to type '<TState, TAction extends Action, TSideEffect = any>(action: Action, state: TState) => ReducerAction<TState, TSideEffect>'.                           
      Types of parameters 'state' and 'state' are incompatible.                                                                                                                                                         
        Type 'TState' is not assignable to type 'State'.
```